### PR TITLE
replacing attr with attrs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*',
     install_requires=[
         'six',
-        'attr',
+        'attrs',
         'pycldf',
         'clldutils',
         'pyglottolog',


### PR DESCRIPTION
Fixes this error:

```
Traceback (most recent call last):
File "/Users/simon/files/Projects/lexibank2018/env/bin/lexibank", line 11, in <module>
  load_entry_point('pylexibank', 'console_scripts', 'lexibank')()
File "/Users/simon/files/Projects/lexibank2018/env/lib/python3.6/site-packages/pkg_resources/__init__.py", line 565, in load_entry_point
  return get_distribution(dist).load_entry_point(group, name)
File "/Users/simon/files/Projects/lexibank2018/env/lib/python3.6/site-packages/pkg_resources/__init__.py", line 2631, in load_entry_point
  return ep.load()
File "/Users/simon/files/Projects/lexibank2018/env/lib/python3.6/site-packages/pkg_resources/__init__.py", line 2291, in load
  return self.resolve()
File "/Users/simon/files/Projects/lexibank2018/env/lib/python3.6/site-packages/pkg_resources/__init__.py", line 2297, in resolve
  module = __import__(self.module_name, fromlist=['__name__'], level=0)
File "/Users/simon/files/Projects/lexibank2018/pylexibank/src/pylexibank/__main__.py", line 30, in <module>
  from pylexibank.glottolog import Glottolog
File "/Users/simon/files/Projects/lexibank2018/pylexibank/src/pylexibank/glottolog.py", line 4, in <module>
  from pyglottolog import api
File "/Users/simon/files/Projects/lexibank2018/env/lib/python3.6/site-packages/pyglottolog-1.1.0-py3.6.egg/pyglottolog/__init__.py", line 3, in <module>
  from .api import Glottolog
File "/Users/simon/files/Projects/lexibank2018/env/lib/python3.6/site-packages/pyglottolog-1.1.0-py3.6.egg/pyglottolog/api.py", line 15, in <module>
  from . import util
File "/Users/simon/files/Projects/lexibank2018/env/lib/python3.6/site-packages/pyglottolog-1.1.0-py3.6.egg/pyglottolog/util.py", line 12, in <module>
  from clldutils.iso_639_3 import ISO, download_tables
File "/Users/simon/files/Projects/lexibank2018/env/lib/python3.6/site-packages/clldutils-2.1.0-py3.6.egg/clldutils/iso_639_3.py", line 19, in <module>
  from csvw.dsv import iterrows
File "/Users/simon/files/Projects/lexibank2018/env/lib/python3.6/site-packages/csvw-1.0-py3.6.egg/csvw/__init__.py", line 3, in <module>
  from .metadata import (TableGroup, Table, Column, ForeignKey,
File "/Users/simon/files/Projects/lexibank2018/env/lib/python3.6/site-packages/csvw-1.0-py3.6.egg/csvw/metadata.py", line 26, in <module>
  from .dsv import Dialect, UnicodeReaderWithLineNumber, UnicodeWriter
File "/Users/simon/files/Projects/lexibank2018/env/lib/python3.6/site-packages/csvw-1.0-py3.6.egg/csvw/dsv.py", line 27, in <module>
  from .dsv_dialects import Dialect
File "/Users/simon/files/Projects/lexibank2018/env/lib/python3.6/site-packages/csvw-1.0-py3.6.egg/csvw/dsv_dialects.py", line 17, in <module>
  non_negative_int = [attr.validators.instance_of(int), _non_negative]
AttributeError: module 'attr' has no attribute ‘validators'
```