### PR TITLE
fix curate crashing on empty input.

### DIFF
--- a/src/pylexibank/commands/curate.py
+++ b/src/pylexibank/commands/curate.py
@@ -59,6 +59,9 @@ def curate(args):
             ).split()
         except EOFError:
             break
+        
+        if len(user_input) == 0:
+            continue  # ignore empty commands
         if user_input[0] not in commands:
             print(colored('Invalid command!', 'red'))
             continue


### PR DESCRIPTION
When running `lexibank curate`, If the user hits return or enters just whitespace, we crash with this error:

```
Traceback (most recent call last):
  File "/Users/simon/files/Projects/lexibank2018/env/bin/lexibank", line 11, in <module>
    load_entry_point('pylexibank', 'console_scripts', 'lexibank')()
  File "/Users/simon/files/Projects/lexibank2018/pylexibank/src/pylexibank/__main__.py", line 118, in main
    sys.exit(parser.main())
  File "/Users/simon/files/Projects/lexibank2018/env/lib/python3.6/site-packages/clldutils-2.1.0-py3.6.egg/clldutils/clilib.py", line 109, in main
    catch_all=catch_all, parsed_args=args)
  File "/Users/simon/files/Projects/lexibank2018/env/lib/python3.6/site-packages/clldutils-2.1.0-py3.6.egg/clldutils/clilib.py", line 81, in main
    self.commands[args.command](args)
  File "/Users/simon/files/Projects/lexibank2018/env/lib/python3.6/site-packages/clldutils-2.1.0-py3.6.egg/clldutils/clilib.py", line 34, in __call__
    return self.func(args)
  File "/Users/simon/files/Projects/lexibank2018/pylexibank/src/pylexibank/commands/curate.py", line 63, in curate
    if user_input[0] not in commands:
IndexError: list index out of range
```

This patch catches the empty user_input condition and simply continues (I felt that it didn't warrant a big red 'invalid input!' message)