### PR TITLE
catch KeyboardInterrupt

### DIFF
--- a/src/pylexibank/commands/curate.py
+++ b/src/pylexibank/commands/curate.py
@@ -60,6 +60,8 @@ def curate(args):  # pragma: no cover
             ).split()
         except EOFError:
             break
+        except KeyboardInterrupt:
+            break
 
         if len(user_input) == 0:
             continue  # ignore empty commands


### PR DESCRIPTION
CTRL-C in curate exits with an ugly traceback, this patch catches KeyboardInterrupt and fails gracefully.