### PR TITLE
Print error message when given an invalid dataset

### DIFF
--- a/src/pylexibank/commands/curate.py
+++ b/src/pylexibank/commands/curate.py
@@ -70,7 +70,7 @@ def curate(args):  # pragma: no cover
         if user_input[0] not in commands:
             print(colored('Invalid command!', 'red'))
             continue
-        if len(user_input) > 0 and user_input[1] not in datasets:
+        if len(user_input) > 1 and user_input[1] not in datasets:
             print(colored('Invalid dataset!', 'red'))
             continue
             

--- a/src/pylexibank/commands/curate.py
+++ b/src/pylexibank/commands/curate.py
@@ -70,7 +70,10 @@ def curate(args):  # pragma: no cover
         if user_input[0] not in commands:
             print(colored('Invalid command!', 'red'))
             continue
-
+        if len(user_input) > 0 and user_input[1] not in datasets:
+            print(colored('Invalid dataset!', 'red'))
+            continue
+            
         args.args = user_input[1:]
         try:
             s = time()


### PR DESCRIPTION
Currently if an argument is given to a command in `curate`, but the argument is not a valid dataset name, the command returns immediately as `args.args = user_input[1:]` is now []. 

This can be confusing as it looks like the command succeeded (when it didn't). I noticed this when I hadn't installed a dataset, but running 'makecldf dataset' was quicker than I expected and didn't make any changes.

This PR now prints an error message on a non-dataset argument. The side effect is that now each 2nd argument has to be a dataset (which I think is ok at the moment, but it may be confining later on).

