### PR TITLE
Fix bare exception and a buggy check

### DIFF
--- a/src/pylexibank/dataset.py
+++ b/src/pylexibank/dataset.py
@@ -194,9 +194,8 @@ class Dataset(object):
         return {}
 
     def __init__(self, concepticon=None, glottolog=None):
-        if self.__class__ != Dataset:
-            if not (self.dir and self.id):
-                raise ValueError
+        if not isinstance(self, Dataset) and not (self.dir and self.id):
+            raise ValueError("Unable to resolve class")
         self.unmapped = Unmapped()
         self.dir = DataDir(self.dir)
         self._json = self.dir.joinpath('lexibank.json')


### PR DESCRIPTION
I ran into a problem with this check, I think it's occurring because the dataset is installed via pip and not `setup.py develop`. It was failing because  `self.__class__` was returning `<class 'lexibank_allenbai.Dataset'>`, instead of `Dataset` (or precisely <class 'pylexibank.dataset.Dataset'>`) so there was a mro glitch. 

Using `isinstance` should fix this and I've also added a better error message rather than a bare exception. 

BUT: I'm not sure what this check is supposed to be doing, so please double check this.