### PR TITLE
Adding read_json utility to DataDir

### DIFF
--- a/src/pylexibank/util.py
+++ b/src/pylexibank/util.py
@@ -168,6 +168,9 @@ class DataDir(type(Path())):
             xml = '<r>{0}</r>'.format(xml)
         return et.fromstring(xml.encode('utf8'))
 
+    def read_json(self, fname, **kw):
+        return jsonlib.load(fname)
+    
     def read_bib(self, fname='sources.bib'):
         bib = database.parse_string(self.read(fname), bib_format='bibtex')
         return [Source.from_entry(k, e) for k, e in bib.entries.items()]


### PR DESCRIPTION
This adds a `read_json` method to `Datadir`, as it's a really useful thing to have (e.g. I'm working on a dataset that provides json via an API - transnewguinea.org). 

One concern is that this then mimics [`Dataset.read_json`](https://github.com/lexibank/pylexibank/blob/9ab74726066d64dd6faee557044771ad67d58e20/src/pylexibank/dataset.py#L226) with slightly different semantics (Dataset.read_json loads lexibank.json, and doesn't take fname or **kw arguments).  

Although, I'm not actually sure why `Dataset.read_json` is used, `Dataset` also loads metadata.json transparently as the property `.metadata`.