### PR TITLE
clean-form

### DIFF
--- a/src/pylexibank/cldf.py
+++ b/src/pylexibank/cldf.py
@@ -108,11 +108,6 @@ class Dataset(object):
                 if form != kw_['Value']:
                     self.dataset.log.debug(
                         'iter_forms split: "{0}" -> "{1}"'.format(kw_['Value'], form))
-                _form = self.dataset.clean_form(kw_, form)
-                if _form != form:
-                    self.dataset.log.debug(
-                        'clean_form changed: "{0}" -> "{1}"'.format(form, _form))
-                form = _form.strip()
                 if form:
                     kw_.setdefault('Segments', self.tokenize(kw_, form) or [])
                     kw_.update(ID=self.lexeme_id(kw), Form=form)

--- a/src/pylexibank/dataset.py
+++ b/src/pylexibank/dataset.py
@@ -325,7 +325,7 @@ class Dataset(object):
 
             def _tokenizer(item, string, **kw):
                 kw.setdefault("column", "IPA")
-                kw.setdefault("separator", " _ ")
+                kw.setdefault("separator", " + ")
                 return tokenizer(unicodedata.normalize('NFC', string), **kw).split()
             return _tokenizer
 


### PR DESCRIPTION
The clean form contains an inconsistency: the form is in fact cleaned twice now, which I spotted, when overriding "clean_form", to account for context in ortho-profiles, which yielded in `^^STRING$$`. So the four lines need to be deleted. Furthermore, as we will keep ` + ` as the only separator for morpheme boundaries, including word boundaries, I propose to replace the underscore by our plus.