### PR TITLE
catch ZeroDivisionError when there are no lexical items

### DIFF
--- a/src/pylexibank/dataset.py
+++ b/src/pylexibank/dataset.py
@@ -527,6 +527,8 @@ class Dataset(object):
         lsclasserr = len(stats['sclass_errors'])
 
         def ratio(prop):
+            if float(totals['lexemes']) == 0:
+                return 0
             return sum(v for k, v in totals[prop].items() if k) / float(totals['lexemes'])
 
         badges = [


### PR DESCRIPTION
This catches a ZeroDivisionError when there are no lexical items -- e.g. when adding a new dataset and you haven't written the item parsing code yet :/