### PR TITLE
All commands using with_dataset don't raise errors if dataset is not installed.

### DIFF
--- a/src/pylexibank/commands/util.py
+++ b/src/pylexibank/commands/util.py
@@ -14,14 +14,21 @@ def get_dataset(args, name=None):
     raise ParserError('invalid dataset spec')  # pragma: no cover
 
 
+class DatasetNotInstalledException(Exception):
+    pass
+
 def with_dataset(args, func, default_to_all=False):
+    found = False
     for dataset in args.cfg.datasets:
         if (dataset.id in args.args) or (default_to_all and not args.args):
+            found = True
             s = time()
             args.log.info('processing %s ...' % dataset.id)
             func(get_dataset(args, dataset.id), **vars(args))
             args.log.info('... done %s [%.1f secs]' % (dataset.id, time() - s))
-
+    if not found:
+        raise DatasetNotInstalledException("No matching dataset found!")
+    
 
 def _load(ds, **kw):
     db = Database(kw['db'])


### PR DESCRIPTION
... this makes for unpredictable errors, e.g. I was wondering why `lexibank makecldf dataset` was completing but not doing anything. The dataset wasn't installed so it with_dataset just terminated without doing anything.

This PR makes a custom exception, which is raised when nothing happens. 