### PR TITLE
Caching glottolog lookups

### DIFF
--- a/src/pylexibank/commands/check.py
+++ b/src/pylexibank/commands/check.py
@@ -17,6 +17,7 @@ def check(args):
     test(args)
 
     # Check languages
+    glottocodes = {l.id for l in ds.glottolog.languoids()}
     print(colored("Checking Languages...", "green"))
     for lang in ds.cldf['LanguageTable']:
         if not lang['Glottocode']:
@@ -25,8 +26,7 @@ def check(args):
                 "yellow"
             ))
         else:
-            found = ds.glottolog.languoid(lang['Glottocode'])
-            if not found:
+            if lang['Glottocode'] not in glottocode:
                 print(colored(
                     "ERROR: Language '%s' has an INVALID glottocode '%s'" % (
                     lang['Name'], lang['Glottocode']),


### PR DESCRIPTION
As suggested by @xrotwang 

Slightly slower for small datasets, but much faster for big ones:

lexibank check birchallchapacuran  9.71s user 5.63s system 88% cpu 17.419 total
lexibank check birchallchapacuran  16.66s user 3.77s system 72% cpu 28.311 total

lexibank check bowernpny  98.22s user 32.69s system 97% cpu 2:13.72 total
lexibank check bowernpny  73.09s user 4.81s system 90% cpu 1:25.71 total

(do we want to do it differently for datasets with less than 100 languages? I though the complication tradeoff was not worth it, but happy to be convinced otherwise)