### PR TITLE
add new command to check for morpheme annotation

### DIFF
--- a/src/pylexibank/commands/misc.py
+++ b/src/pylexibank/commands/misc.py
@@ -153,6 +153,11 @@ def check_profile(args):
     """Check orthography of a dataset"""
     with_dataset(args, Dataset._check_profile)
 
+@command('check-morphemes')
+def check_phonotactics(args):
+    """Check the segmented forms of a dataset"""
+    with_dataset(args, Dataset._check_phonotactics)
+
 @command()
 def db(args):
     db = str(Database(args.db).fname)


### PR DESCRIPTION
What this command does is th efollowing:

```
(base) [mattis@otto lexibank-calc]$ lexibank check-morphemes allenbai
Using configuration file at:
/home/mattis/.config/pylexibank/config.ini

INFO    processing allenbai ...
# Segments end in +:
|   No | ID            | Form       | Segments          |
|-----:|:--------------|:-----------|:------------------|
|    1 | Lanping-235-1 | fɛ⁴⁴(kɔ̃³¹) | f ɛ ⁴⁴ + k ɔ̃ ³¹ + |

```

It is important for data containing morpheme segmentation, as they should not have a plus symbol before a word, after or word, or two in a row (all would not make sense).