### PR TITLE
add_cognates expects a lexeme instance implicitly

### DIFF
--- a/src/pylexibank/cldf.py
+++ b/src/pylexibank/cldf.py
@@ -215,6 +215,8 @@ class LexibankWriter(CLDFWriter):
 
     def add_cognate(self, lexeme=None, **kw):
         if lexeme:
+            if not isinstance(lexeme, self.dataset.lexeme_class):
+                raise TypeError("add_cognate expects a lexeme instance")
             kw.setdefault('Form_ID', lexeme['ID'])
             kw.setdefault('Form', lexeme['Form'])
         kw.setdefault('ID', self.cognate_id(kw))


### PR DESCRIPTION
...I tried to give add_concept a lexeme_id by mistake and got the following error, which took me a while to figure out:

```
TypeError: string indices must be integers
```

... So, this PR checks that lexeme is a instance of the defined dataset class and makes the error more explicit. 

On the one hand,  this makes it explicit that the lexeme should be the same thing as the class defines, BUT this stops duck typing and it might be nice to be able to pass lexicon ids,  so it might be preferable to do something like:

```python
if isinstance(lexeme, BaseLexemeWhateverItsCalled):
    kw.setdefault('Form_ID', lexeme['ID'])

.. or:
if hasattr(lexeme, 'ID'): ...
```