### PR TITLE
Implement replacements in FormSpec

### DIFF
--- a/src/pylexibank/dataset.py
+++ b/src/pylexibank/dataset.py
@@ -218,6 +218,7 @@ class Dataset(BaseDataset):
         tr = self.cldf_dir / '.transcription-report.json'
         tr = jsonlib.load(tr) if tr.exists() else None
         res += report.report(self, tr, getattr(args, 'glottolog', None), args.log)
+        self.dir.write('FORMS.md', self.form_spec.as_markdown())
         return res
 
 

--- a/src/pylexibank/forms.py
+++ b/src/pylexibank/forms.py
@@ -21,6 +21,15 @@ def valid_replacements(instance, attribute, value):
             raise ValueError('replacements must be list of pairs')
 
 
+def valid_separators(instance, attribute, value):
+    if not isinstance(value, str):
+        if not isinstance(value, (list, tuple)):
+            raise ValueError('separators must be an iterable of single character strings')
+        for v in value:
+            if (not isinstance(v, str)) or len(v) > 1:
+                raise ValueError('separators must be an iterable of single character strings')
+
+
 def attrib(help, **kw):
     kw['metadata'] = dict(help=help)
     return attr.ib(**kw)
@@ -45,7 +54,8 @@ class FormSpec(object):
     )
     separators = attrib(
         "Iterable of single character tokens that should be recognized as word separator",
-        default=";/,",
+        default=(";", "/", ","),
+        validator=valid_separators,
     )
     missing_data = attrib(
         "Iterable of strings that are used to mark missing data",

--- a/src/pylexibank/forms.py
+++ b/src/pylexibank/forms.py
@@ -29,15 +29,13 @@ def attrib(help, **kw):
 @attr.s
 class FormSpec(object):
     """
-    Specification of the value-to-form processing in Lexibank datasets.
+    Specification of the value-to-form processing in Lexibank datasets:
 
     The value-to-form processing is divided into two steps, implemented as methods:
-    - `split`: Splits a string into individual form chunks.
-    - `clean`: Normalizes a form chunk.
+    - `FormSpec.split`: Splits a string into individual form chunks.
+    - `FormSpec.clean`: Normalizes a form chunk.
 
     These methods use the attributes of a `FormSpec` instance to configure their behaviour.
-    Thus, rather than overwriting these methods in a drived class, datasets should use
-    suitably initialized `FormSpec` instances to transparently massage data.
     """
     brackets = attrib(
         "Pairs of strings that should be recognized as brackets, specified as `dict` "
@@ -87,6 +85,7 @@ class FormSpec(object):
         :return: Description of `FormSpec` in markdown.
         """
         res = ['## Specification of form manipulation\n']
+        res.extend([line.strip() for line in self.__class__.__doc__.splitlines()])
         for field in attr.fields(self.__class__):
             res.extend([
                 '- `{0}`: `{1}`'.format(field.name, getattr(self, field.name)),

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -60,6 +60,7 @@ def test_init_profile(dataset, repos):
 
 def test_readme(dataset, repos):
     _main('lexibank.readme {0} --glottolog {1}'.format(str(dataset.dir / 'td.py'), repos))
+    assert dataset.dir.joinpath('FORMS.md').exists()
 
 
 def test_new(tmpdir, mocker):

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -15,6 +15,25 @@ def test_split():
     assert spec.split({}, 'x', lexemes={'x': 'x;y'}) == ['x']
 
 
+def test_markdown():
+    spec = FormSpec()
+    assert spec.as_markdown()
+
+
+def test_normalize_whitespace():
+    spec = FormSpec()
+    assert spec.clean(' a\t b\n') == 'a b'
+
+    spec = FormSpec(normalize_whitespace=False, strip_inside_brackets=False)
+    assert spec.clean(' a\t b\n') == ' a\t b\n'
+
+
+def test_normalize_unicode():
+    spec = FormSpec(normalize_unicode='NFD', separators='\u0308')
+    # The combining diaresis is used as separator:
+    assert len(spec.split(None, 'äb')) == 2
+
+
 def test_replacements():
     spec = FormSpec(replacements=[('x', 'y')])
     assert spec.clean('x') == 'y'

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -11,6 +11,10 @@ def test_split():
     spec.strip_inside_brackets = False
     assert spec.split({}, 'x(a)') == ['x(a)']
 
+    spec = FormSpec(separators='|')
+    assert spec.split(None, 'x|y') == ['x', 'y']
+    assert spec.split(None, 'x;y') == ['x;y']
+
     spec = FirstFormOnlySpec()
     assert spec.split({}, 'x', lexemes={'x': 'x;y'}) == ['x']
 

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -1,3 +1,5 @@
+import pytest
+
 from pylexibank.forms import *
 
 
@@ -11,3 +13,15 @@ def test_split():
 
     spec = FirstFormOnlySpec()
     assert spec.split({}, 'x', lexemes={'x': 'x;y'}) == ['x']
+
+
+def test_replacements():
+    spec = FormSpec(replacements=[('x', 'y')])
+    assert spec.clean('x') == 'y'
+    assert spec.clean('y') == 'y'
+
+    with pytest.raises(ValueError):
+        FormSpec(replacements=())
+
+    with pytest.raises(ValueError):
+        FormSpec(replacements=[(1, 2)])


### PR DESCRIPTION
Note that this already increases the complexity of what `FormSpec.clean`
does: Now, stripping bracketed content depends on the result of the
replacements. This may be a feature, but could be a trap.

Closes #142