### PR TITLE
faster compilation if glottolog data is sufficient

### DIFF
--- a/src/pylexibank/cldf.py
+++ b/src/pylexibank/cldf.py
@@ -248,6 +248,13 @@ class LexibankWriter(CLDFWriter):
 
     def add_language(self, **kw):
         if 'Glottocode' in kw \
+                and 'Latitude' in kw \
+                and 'Longitude' in kw \
+                and 'Macroarea' in kw \
+                and 'Family' in kw \
+                and 'ISO6339P3code' in kw:
+            pass
+        elif 'Glottocode' in kw \
                 and hasattr(self.args, 'glottolog') \
                 and kw['Glottocode'] in self.args.glottolog.api.cached_languoids:
             glang = self.args.glottolog.api.cached_languoids[kw['Glottocode']]


### PR DESCRIPTION
If all data that glottolog normally provides are passed, this will prevent pylexibank from calling glottolog and sufficiently speed up the creation process (when fixing smaller bugs, even 30 seconds are unbearable, so one can make sure all langauge info is in place, and then saves time in working on form spec etc.). 