### PR TITLE
refactor ABVD provider

### DIFF
--- a/src/pylexibank/providers/abvd.py
+++ b/src/pylexibank/providers/abvd.py
@@ -25,9 +25,9 @@ class BVD(Dataset):
     invalid_ids = []
     max_language_id = 50 # maximum language id to look for.
     language_class = BVDLanguage
-    cognate_pattern = re.compile('\s*(?P<id>([A-z]?[0-9]+|[A-Z]))\s*(?P<doubt>\?+)?\s*$')
+    cognate_pattern = re.compile(r'''\s*(?P<id>([A-z]?[0-9]+|[A-Z]))\s*(?P<doubt>\?+)?\s*$''')
     
-    def iter_wordlists(self, log):
+    def iter_wordlists(self, log=None):
         for xml in sorted(self.raw_dir.glob('*.xml'), key=lambda p: int(p.stem)):
             yield Wordlist(self, xml, log)
 
@@ -196,7 +196,8 @@ class Wordlist(object):
                 self.dataset.unmapped.add_concept(ID=entry.word_id, Name=entry.word)
                 # add it if we don't have it.
                 ds.add_concept(ID=entry.word_id, Name=entry.word)
-            
+                cid = entry.word_id
+                
             # handle lexemes
             try:
                 lex = ds.add_forms_from_value(
@@ -211,7 +212,7 @@ class Wordlist(object):
                     Comment=entry.comment or '',
                     Loan=True if entry.loan and len(entry.loan) else False,
                 )
-            except:
+            except:  # pragma: no cover
                 print("ERROR with %r -- %r" % (entry.id, entry.name))
                 raise
                 

--- a/src/pylexibank/providers/abvd.py
+++ b/src/pylexibank/providers/abvd.py
@@ -39,7 +39,7 @@ class BVD(Dataset):
             fname.unlink()
         
         for lid in range(1, self.max_language_id + 1):
-            if i in self.invalid_ids:
+            if lid in self.invalid_ids:
                 args.log.warn("Skipping %s %d - invalid ID" % (self.SECTION, lid))
                 break
             

--- a/src/pylexibank/providers/abvd.py
+++ b/src/pylexibank/providers/abvd.py
@@ -41,7 +41,7 @@ class BVD(Dataset):
         for lid in range(1, self.max_language_id + 1):
             if lid in self.invalid_ids:
                 args.log.warn("Skipping %s %d - invalid ID" % (self.SECTION, lid))
-                break
+                next
             
             if not self.get_data(lid):
                 args.log.warn("No content for %s %d. Ending." % (self.SECTION, lid))
@@ -131,6 +131,7 @@ class Entry(XmlElement):
 
 
 class Wordlist(object):
+    
     def __init__(self, dataset, path, log):
         self.dataset = dataset
         self.log = log
@@ -178,8 +179,11 @@ class Wordlist(object):
         source = []
         if self.language.source:
             bib = parse_string(self.language.source, "bibtex")
-            ds.add_sources(*[Source.from_entry(k, e) for k, e in bib.entries.items()])
-            source = bib.entries.keys()
+            try:
+                ds.add_sources(*[Source.from_entry(k, e) for k, e in bib.entries.items()])
+                source = bib.entries.keys()
+            except:
+                self.log.warn("Invalid citekey for %s" % self.language.id)
         
         for entry in self.entries:
             if entry.name is None or len(entry.name) == 0:  # skip empty entries
@@ -230,7 +234,7 @@ class Wordlist(object):
                             lexeme=lex[0],
                             Cognateset_ID=cs_id,
                             Doubt=bool(match.group('doubt')),
-                            Source=['Greenhilletal2008']
+                            Source=['Greenhilletal2008'] if self.section == 'austronesian' else []
                         )
 
         return ds

--- a/tests/repos/datasets/abvd/raw/1.xml
+++ b/tests/repos/datasets/abvd/raw/1.xml
@@ -8,6 +8,13 @@
 	<classification>Austronesian, Malayo-Polynesian, Bali-Sasak-Sumbawa</classification>
 	<typedby>Peng Du</typedby>
 	<checkedby>Simon Greenhill</checkedby>
+	<source>
+    @misc{Denes-1-2005,
+        author = {Denes, Made},
+        date = {2005},
+        howpublished = {personal communication}
+    }
+	</source>
 </record>
 
 <record>

--- a/tests/test_providers_abvd.py
+++ b/tests/test_providers_abvd.py
@@ -21,20 +21,9 @@ def abvd_dataset(repos, tmpdir, glottolog, concepticon):
 
 def test_Wordlist(abvd_dataset, mocker):
     with abvd_dataset.cldf_writer(mocker.MagicMock()) as ds:
-        for wl in abvd_dataset.iter_wordlists({'1': 'bali1278'}, None):
-            wl.to_cldf(ds, {}, citekey='x',source='s')
+        for wl in abvd_dataset.iter_wordlists():
+            wl.to_cldf(ds, {})
             assert wl.name
             assert wl.id
-            assert wl.md()
 
 
-def test_Wordlist_2(abvd_dataset, mocker):
-    with abvd_dataset.cldf_writer(mocker.MagicMock()) as ds:
-        for wl in abvd_dataset.iter_wordlists({'1': 'bali1278'}, None):
-            wl.to_cldf(ds, {}, citekey='x', source=[Source('a', 'b', **dict(title='t'))])
-
-
-def test_Wordlist_3(abvd_dataset, mocker):
-    with abvd_dataset.cldf_writer(mocker.MagicMock()) as ds:
-        for wl in abvd_dataset.iter_wordlists({'1': 'bali1278'}, None):
-            wl.to_cldf(ds, {})


### PR DESCRIPTION
This refactors the ABVD. In particular:

1. the sources are now stored in the database, and imported from there.
2. the cognates are now 'global' (rather than local)
3. the database level attributes (e.g. invalid id's etc are handled at the level of the dataset rather than the provider so it's closer to the action).


Only thing I don't like is that because 'source' is now an attribute of language storing the bibtex record, the languages.csv file has this as a column (how do I remove this?)