### PR TITLE
adding cognate check

### DIFF
--- a/src/pylexibank/commands/check.py
+++ b/src/pylexibank/commands/check.py
@@ -7,8 +7,9 @@ from pylexibank.cli_util import add_dataset_spec
 
 from pylexibank.commands.check_languages import check as check_languages
 from pylexibank.commands.check_lexibank import check as check_lexibank
+from pylexibank.commands.check_cognates import check as check_cognates
 
-CHECKERS = [check_languages, check_lexibank]
+CHECKERS = [check_languages, check_lexibank, check_cognates]
 
 def register(parser):
     add_dataset_spec(parser, multiple=True)

--- a/src/pylexibank/commands/check_cognates.py
+++ b/src/pylexibank/commands/check_cognates.py
@@ -1,0 +1,44 @@
+"""
+Check cognates table
+"""
+import functools
+from collections import defaultdict
+from cldfbench.cli_util import with_datasets, add_catalog_spec
+from pylexibank.cli_util import add_dataset_spec, warning
+
+
+def register(parser):
+    add_dataset_spec(parser, multiple=True)
+    add_catalog_spec(parser, 'glottolog')
+
+def check(ds, args):
+    warn = functools.partial(warning, args, dataset=ds)
+    cldf = ds.cldf_reader()
+    
+    if cldf["CognateTable"].common_props.get('dc:extent') == 0:
+        # NOTE: this is using the metadata to identify if we
+        # have cognates or not. Is there a better way?
+        return
+    
+    args.log.info('checking {0} - cognates'.format(ds))
+    
+    # do cognate sets span different words?
+    # i.e. we want 'global' cognate ids so cognate sets should be 
+    # found in one word/parameter only.
+    cognates = {}
+    for row in cldf['CognateTable']:
+        cognates[row['Form_ID']] = row['Cognateset_ID']
+    
+    cogs_by_param = defaultdict(set)
+    for row in cldf['FormTable']:
+        cogset = cognates.get(row['ID'])
+        if cogset:
+            cogs_by_param[cogset].add(row['Parameter_ID'])
+        
+    for c in cogs_by_param:
+        if len(cogs_by_param[c]) > 1:
+            warn('Cognate set {0} is not global: {1}'.format(c, cogs_by_param[c]))
+        
+
+def run(args):
+    with_datasets(args, check)


### PR DESCRIPTION
This adds a (fairly expensive) check that cognate sets are global. I couldn't think of a more efficient way to do this (short of making cognates.csv store Form_ID so we only need one table iteration). 

However, it's not usually too expensive -- ABVD which is one of our worst case scenarios here takes 34s. 