### PR TITLE
adding cldf check

### DIFF
--- a/src/pylexibank/commands/check.py
+++ b/src/pylexibank/commands/check.py
@@ -7,8 +7,9 @@ from pylexibank.cli_util import add_dataset_spec
 
 from pylexibank.commands.check_languages import check as check_languages
 from pylexibank.commands.check_lexibank import check as check_lexibank
+from pylexibank.commands.check_cldf import check as check_cldf
 
-CHECKERS = [check_languages, check_lexibank]
+CHECKERS = [check_languages, check_lexibank, check_cldf]
 
 def register(parser):
     add_dataset_spec(parser, multiple=True)

--- a/src/pylexibank/commands/check_cldf.py
+++ b/src/pylexibank/commands/check_cldf.py
@@ -1,0 +1,39 @@
+"""
+Check lexibank plumbing for lexibank datasets
+"""
+import functools
+
+from cldfbench.cli_util import with_datasets, add_catalog_spec
+from pylexibank.cli_util import add_dataset_spec, warning
+
+def register(parser):
+    add_dataset_spec(parser, multiple=True)
+    add_catalog_spec(parser, 'glottolog')
+
+
+def get_cldfprop_version(cldf, title):
+    for repo in cldf.properties.get("prov:wasDerivedFrom", []):
+        if repo.get('dc:title') == title:
+            return repo.get('dc:created')
+
+
+def check(ds, args):
+    warn = functools.partial(warning, args, dataset=ds)
+
+    args.log.info('checking {0} - CLDF'.format(ds))
+    cldf = ds.cldf_reader()
+    
+    repo_version = ds.repo.hash()
+    cldf_version = get_cldfprop_version(cldf, 'Repository')
+    
+    if not cldf_version:
+        warn('Dataset has not git commit id in CLDF')
+    elif repo_version != cldf_version:
+        warn('Dataset compiled with different git commit id (repos={0}, cldf={1})'.format(
+            repo_version,
+            cldf_version
+        ))
+
+
+def run(args):
+    with_datasets(args, check)


### PR DESCRIPTION
This checks if the CLDF was generated by a different version of the repository to what exists (i.e. intended to catch outdated datasets that may need to have makecldf rerun).