### PR TITLE
set python version to current pylexibank version

### DIFF
--- a/src/pylexibank/dataset_templates/lexibank_simple/setup.py_tmpl
+++ b/src/pylexibank/dataset_templates/lexibank_simple/setup.py_tmpl
@@ -20,7 +20,7 @@ setup(
         ]
     }},
     install_requires=[
-        'pylexibank>=2.1',
+        'pylexibank>={version}',
     ],
     extras_require={{
         'test': [

--- a/src/pylexibank/metadata.py
+++ b/src/pylexibank/metadata.py
@@ -1,9 +1,10 @@
 import attr
-
+import pkg_resources
 from cldfbench.metadata import Metadata
 
 __all__ = ['LexibankMetadata']
 
+version = pkg_resources.get_distribution('pylexibank').version
 
 @attr.s
 class LexibankMetadata(Metadata):
@@ -16,6 +17,7 @@ class LexibankMetadata(Metadata):
     related = attr.ib(default=None)
     source = attr.ib(default=None)
     patron = attr.ib(default=None)
+    version = attr.ib(default=version)
 
     def common_props(self):
         res = super().common_props()


### PR DESCRIPTION
fixes #168.

Note that importing from pylexibank directly gives a circular reference, so we use pkg_resources to get the installed version.