### PR TITLE
Provide logic for title format check

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,12 +28,12 @@ setup(
     platforms='any',
     python_requires='>=3.5',
     install_requires=[
+        'attrs>=19.2',
         'segments>=2.1.1',
         'cldfbench[excel]>=1.0',
         'csvw>=1.5.6',
         'clldutils>=2.8.0',
         'pycldf>=1.7.0',
-        'attrs>=18.1.0',
         'pyglottolog>=2.0',
         'pyconcepticon>=2.1.0',
         'pyclts>=2.0',

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
         'dev': ['flake8', 'wheel', 'twine'],
         'test': [
             'mock',
-            'pytest>=3.6',
+            'pytest>=5',
             'pytest-mock',
             'pytest-cov',
             'coverage>=4.2',

--- a/src/pylexibank/metadata.py
+++ b/src/pylexibank/metadata.py
@@ -33,7 +33,7 @@ def check_standard_title(title):
     Note that this requires installing `pylexibank` for tests, also in .travis.yml.
     """
     match = STANDARD_TITLE_PATTERN.fullmatch(title)
-    assert match and match.group('authors').strip().endswith("'s")
+    assert match and match.group('authors').strip().endswith(("'s", "s'"))
 
 
 @attr.s

--- a/src/pylexibank/metadata.py
+++ b/src/pylexibank/metadata.py
@@ -1,11 +1,39 @@
+import re
 import pkg_resources
 
 import attr
 from cldfbench.metadata import Metadata
 
-__all__ = ['LexibankMetadata']
+__all__ = ['LexibankMetadata', 'check_standard_title']
 
 version = pkg_resources.get_distribution('pylexibank').version
+
+STANDARD_TITLE_PATTERN = re.compile(
+    r'CLDF dataset derived from\s+'
+    r'(?P<authors>[^"]+)'
+    r'"(?P<title>[^"]+)"\s+from\s+'
+    r'(?P<year>[0-9]{4})'
+)
+
+
+def check_standard_title(title):
+    """
+    Assert a title conforms to the standard format.
+
+    > CLDF dataset derived from AUTHOR's "TITLE" from YEAR
+
+    Usage: In a dataset's `test.py`:
+    ```python
+    from pylexibank import check_standard_title
+
+    def test_valid_title(cldf_dataset, cldf_logger):
+        check_standard_title(cldf_dataset.metadata_dict['dc:title'])
+    ```
+
+    Note that this requires installing `pylexibank` for tests, also in .travis.yml.
+    """
+    match = STANDARD_TITLE_PATTERN.fullmatch(title)
+    assert match and match.group('authors').strip().endswith("'s")
 
 
 @attr.s

--- a/src/pylexibank/metadata.py
+++ b/src/pylexibank/metadata.py
@@ -24,13 +24,13 @@ def check_standard_title(title):
 
     Usage: In a dataset's `test.py`:
     ```python
-    from pylexibank import check_standard_title
+    import os, pytest
 
+    @pytest.mark.skipif("TRAVIS" in os.environ and os.environ["TRAVIS"] == "true")
     def test_valid_title(cldf_dataset, cldf_logger):
+        from pylexibank import check_standard_title
         check_standard_title(cldf_dataset.metadata_dict['dc:title'])
     ```
-
-    Note that this requires installing `pylexibank` for tests, also in .travis.yml.
     """
     match = STANDARD_TITLE_PATTERN.fullmatch(title)
     assert match and match.group('authors').strip().endswith(("'s", "s'"))

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -26,4 +26,5 @@ def test_invalid_standard_title(title):
 
 def test_valid_standard_title():
     assert check_standard_title(STANDARD_TITLE) is None
+    assert check_standard_title(STANDARD_TITLE.replace(" et al.'s", "brams'")) is None
 

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,3 +1,5 @@
+import pytest
+
 from pylexibank.metadata import *
 
 
@@ -5,3 +7,23 @@ def test_conceptlist():
     md = LexibankMetadata(conceptlist='Swadesh-1964-100', related='abc')
     assert isinstance(md.conceptlist, list)
     assert 'concepticon.clld.org' in md.markdown()
+
+
+STANDARD_TITLE = """CLDF dataset derived from A et al.'s "Paper" from 1934"""
+
+
+@pytest.mark.parametrize('title', [
+    "",
+    STANDARD_TITLE.replace('CLDF', 'cldf'),
+    STANDARD_TITLE.replace("et al.'s", 'et al.’s'),
+    STANDARD_TITLE.replace('"', "'"),
+    STANDARD_TITLE.replace('1934', '34'),
+])
+def test_invalid_standard_title(title):
+    with pytest.raises(AssertionError):
+        check_standard_title(title)
+
+
+def test_valid_standard_title():
+    assert check_standard_title(STANDARD_TITLE) is None
+


### PR DESCRIPTION
Note that using the new function `check_standard_title` requires installing `pylexibank` for tests, e.g. by adapting `.travis.yml`.

closes #213