### PR TITLE
Alter ABVD provider to make it easier to download subsets of the data

### DIFF
--- a/src/pylexibank/providers/abvd.py
+++ b/src/pylexibank/providers/abvd.py
@@ -6,7 +6,7 @@ from pycldf.sources import Source
 from pybtex.database import parse_string  # dependency of pycldf, so should be installed.
 from pylexibank import Dataset, Language
 
-BASE_URL = "https://abvd.shh.mpg.de"
+BASE_URL = "https://abvd.eva.mpg.de"
 URL = BASE_URL + "/utils/save/?type=xml&section=%s&language=%d"
 
 

--- a/src/pylexibank/providers/abvd.py
+++ b/src/pylexibank/providers/abvd.py
@@ -23,7 +23,7 @@ class BVDLanguage(Language):
 class BVD(Dataset):
     SECTION = None
     invalid_ids = []
-    max_language_id = 50  # maximum language id to look for.
+    language_ids = list(range(1, 50)) # list of language ids to look for.
     language_class = BVDLanguage
     cognate_pattern = re.compile(r'''\s*(?P<id>([A-z]?[0-9]+|[A-Z]))\s*(?P<doubt>\?+)?\s*$''')
 
@@ -38,7 +38,7 @@ class BVD(Dataset):
         for fname in self.raw_dir.iterdir():
             fname.unlink()
 
-        for lid in range(1, self.max_language_id + 1):
+        for lid in self.language_ids:
             if lid in self.invalid_ids:
                 args.log.warning("Skipping %s %d - invalid ID" % (self.SECTION, lid))
                 continue


### PR DESCRIPTION
This changes the ABVD provider to take a list of language ids rather than a single max id. This makes it easier to download a subset of the data in future projects.