### PR TITLE
Profile patch

### DIFF
--- a/src/pylexibank/commands/check_profile.py
+++ b/src/pylexibank/commands/check_profile.py
@@ -80,6 +80,9 @@ def check_profile(dataset, args):
                         modified[tk] += [(" ".join(tokens), row["Form"], row["Graphemes"])]
                     elif visited[tk] == "generated":
                         generated[tk] += [(" ".join(tokens), row["Form"], row["Graphemes"])]
+                    elif visited[tk] == "slashed":
+                        slashed[tk] += [(" ".join(tokens), row["Form"],
+                        row["Graphemes"])]
 
     if generated:
         print("# Found {0} generated graphemes".format(len(generated)))

--- a/src/pylexibank/commands/language_profiles.py
+++ b/src/pylexibank/commands/language_profiles.py
@@ -9,6 +9,7 @@ from pylexibank.cli_util import add_dataset_spec
 from pathlib import Path
 from collections import defaultdict
 from pylexibank import progressbar
+from csvw.dsv import UnicodeDictReader
 
 
 def register(parser):
@@ -24,14 +25,22 @@ def run(args):
 
     ds = get_dataset(args)
     wordlist = Dataset.from_metadata(ds.cldf_dir / "cldf-metadata.json")
+    p = ds.etc_dir / "orthography.tsv"
+    if not p.exists():
+        raise ParserError("profile does not exist but is needed for creation")
+    with UnicodeDictReader(p, delimiter="\t") as reader:
+        profile = {}
+        for row in reader:
+            profile[row["Grapheme"]] = row["IPA"]
+
     
     for language in progressbar(
             wordlist.objects("LanguageTable"), 
             desc="creating profiles"):
         data = defaultdict(int)
         for form in language.forms:
-            for grapheme, segment in zip(form.data["Graphemes"], form.data["Segments"]):
-                data[(grapheme, segment)] += 1
+            for grapheme in form.data["Graphemes"]:
+                data[grapheme, profile.get(grapheme, "?")] += 1
         new_path = ds.etc_dir / "orthography" / "{0}.tsv".format(language.id)
         if new_path.exists() and not args.force:
             raise ParserError("Orthography profile exists, use --force to override")

--- a/src/pylexibank/commands/language_profiles.py
+++ b/src/pylexibank/commands/language_profiles.py
@@ -1,0 +1,47 @@
+"""
+Create a profile for individual languages from an already prepared general profile.
+"""
+from cldfbench.cli_util import get_dataset
+from clldutils.clilib import ParserError
+from pycldf import Dataset
+
+from pylexibank.cli_util import add_dataset_spec
+from pathlib import Path
+from collections import defaultdict
+from pylexibank import progressbar
+
+
+def register(parser):
+    add_dataset_spec(parser)
+    parser.add_argument(
+        '-f', '--force',
+        action='store_true',
+        help='Overwrite existing profile',
+        default=False)
+
+
+def run(args):
+
+    ds = get_dataset(args)
+    wordlist = Dataset.from_metadata(ds.cldf_dir / "cldf-metadata.json")
+    
+    for language in progressbar(
+            wordlist.objects("LanguageTable"), 
+            desc="creating profiles"):
+        data = defaultdict(int)
+        for form in language.forms:
+            for grapheme, segment in zip(form.data["Graphemes"], form.data["Segments"]):
+                data[(grapheme, segment)] += 1
+        new_path = ds.etc_dir / "orthography" / "{0}.tsv".format(language.id)
+        if new_path.exists() and not args.force:
+            raise ParserError("Orthography profile exists, use --force to override")
+        with open(
+                new_path,
+                "w",
+                encoding="utf-8") as f:
+            f.write("{0}\t{1}\t{2}\n".format("Grapheme", "IPA", "Frequency"))
+            for (g, s), freq in sorted(
+                    data.items(), key=lambda x: x[1],
+                    reverse=True):
+                f.write("{0}\t{1}\t{2}\n".format(g, s, freq))
+

--- a/src/pylexibank/commands/language_profiles.py
+++ b/src/pylexibank/commands/language_profiles.py
@@ -39,7 +39,7 @@ def run(args):
             desc="creating profiles"):
         data = defaultdict(int)
         for form in language.forms:
-            for grapheme in form.data["Graphemes"]:
+            for grapheme in form.data["Graphemes"].split():
                 data[grapheme, profile.get(grapheme, "?")] += 1
         new_path = ds.etc_dir / "orthography" / "{0}.tsv".format(language.id)
         if new_path.exists() and not args.force:


### PR DESCRIPTION
We have been using code to generate language-specific profiles for some time now. The code that we used to make language-specific profiles form "normal" profiles was always copy-pasted, and it is time to add it to pylexibank.

The code is EXTREMELY easy: we load the profile as a dictionary, we iterate over Graphemes in the data, and we add each IPA segment we find there. 

The typical workflow now is:

1. make a general profile for a dataset
2. use `cldfbench lexibank.language_profiles DATASET` to make language-specific profiles
3. edit those profiles

