### PR TITLE
Glottocode instead of Glottolog

### DIFF
--- a/src/pylexibank/dataset_templates/lexibank_simple/lexibank_+id+.py_tmpl
+++ b/src/pylexibank/dataset_templates/lexibank_simple/lexibank_+id+.py_tmpl
@@ -60,7 +60,7 @@ class Dataset(pylexibank.Dataset):
         #for language in self.languages:
         #    args.writer.add_language(
         #        ID=language['ID'],
-        #        Glottolog=language['Glottolog']
+        #        Glottocode=language['Glottocode']
         #    )
 
         # add data


### PR DESCRIPTION
The template uses a `Glottolog` argument for `add_language`. This results in `TypeError: __init__() got an unexpected keyword argument 'Glottolog'`.