### PR TITLE
Explicitly set encoding for metadata

### DIFF
--- a/src/pylexibank/metadata.py
+++ b/src/pylexibank/metadata.py
@@ -385,7 +385,7 @@ def iter_rows(fname_or_lines):
     def row(line):
         return [li.strip() for li in line.split('|')]
 
-    for line in (fname_or_lines if isinstance(fname_or_lines, list) else fname_or_lines.open()):
+    for line in (fname_or_lines if isinstance(fname_or_lines, list) else fname_or_lines.open(encoding='utf-8')):
         if in_table:
             if '|' not in line:  # Last row of table was already read
                 break


### PR DESCRIPTION
On Windows, UTF-8 needs to be explicitly set as encoding for writing the metadata, see https://github.com/lexibank/pylexibank/issues/272#issuecomment-1803902903.

NB: 'UTF-8' mode can be enforced on Windows platforms with `PYTHONUTF8=1`. I'm not sure whether recommending doing this is preferable to explicitly setting the encoding.