### PR TITLE
Show warning when unreferenced languages or parameters are dropped

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.8, 3.9, "3.10", 3.11, 3.12]
 
     steps:
     - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changes
+
+The `pylexibank` package adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+- Changed behaviour of makecldf so it does not remove languages or parameters explicitly added by the user.
+- Run tests on python 3.8–3.12

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -16,6 +16,8 @@ flake8 src
   - `setup.cfg`
   - `src/pylexibank/__init__.py`
 
+- In `CHANGELOG.md`, move the changes under the *Unreleased* heading to a new section with the new version number as its heading.
+
 - Create the release commit:
 ```shell
 git commit -a -m "release <VERSION>"

--- a/setup.cfg
+++ b/setup.cfg
@@ -109,7 +109,7 @@ exclude_lines =
     pragma: no cover
 
 [tox:tox]
-envlist = py37, py38, py39, py310, py311
+envlist = py38, py39, py310, py311, py312
 isolated_build = true
 skip_missing_interpreter = true
 

--- a/src/pylexibank/cldf.py
+++ b/src/pylexibank/cldf.py
@@ -107,18 +107,6 @@ class LexibankWriter(CLDFWriter):
                 t for t in self.cldf.tables if str(t.url) != 'cognates.csv']
             if 'CognateTable' in self.objects:
                 del self.objects['CognateTable']
-
-        # We only add concepts and languages that are referenced by forms!
-        for fk, table in [('Parameter_ID', 'ParameterTable'), ('Language_ID', 'LanguageTable')]:
-            if (table == 'Parameter_ID' and self.options.keep_parameters) or \
-                    (table == 'LanguageTable' and self.options.keep_languages):
-                continue
-            refs = {obj[fk] for obj in self.objects['FormTable']}
-            referenced_objects = [obj for obj in self.objects[table] if obj['ID'] in refs]
-            if len(referenced_objects) < len(self.objects[table]):
-                log.warning('{}: Ignoring {} rows because they are not referenced_objects by any forms.'.format(
-                    table, len(self.objects[table]) - len(referenced_objects)))
-            self.objects[table] = referenced_objects
         super().__exit__(exc_type, exc_val, exc_tb)
 
     def add_sources(self, *args):

--- a/src/pylexibank/cldf.py
+++ b/src/pylexibank/cldf.py
@@ -113,8 +113,12 @@ class LexibankWriter(CLDFWriter):
             if (table == 'Parameter_ID' and self.options.keep_parameters) or \
                     (table == 'LanguageTable' and self.options.keep_languages):
                 continue
-            refs = set(obj[fk] for obj in self.objects['FormTable'])
-            self.objects[table] = [obj for obj in self.objects[table] if obj['ID'] in refs]
+            refs = {obj[fk] for obj in self.objects['FormTable']}
+            referenced_objects = [obj for obj in self.objects[table] if obj['ID'] in refs]
+            if len(referenced_objects) < len(self.objects[table]):
+                log.warning('{}: Ignoring {} rows because they are not referenced_objects by any forms.'.format(
+                    table, len(self.objects[table]) - len(referenced_objects)))
+            self.objects[table] = referenced_objects
         super().__exit__(exc_type, exc_val, exc_tb)
 
     def add_sources(self, *args):

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -68,7 +68,7 @@ def test_db_multiple_datasets(dataset, dataset_cldf, dataset_cldf_capitalisation
     db.load(dataset_cldf_capitalisation, verbose=True)
     with db.connection() as conn:
         res = db.fetchall('select `id`, `name` from LanguageTable', conn=conn)
-        assert len(res) == 4
+        assert len(res) == 6
         assert ('1', 'Lang CLDF') in [(r[0], r[1]) for r in res]
         res = db.fetchall('select `id`, `value` from FormTable', conn=conn)
         assert ('1', 'abc') in [(r[0], r[1]) for r in res]


### PR DESCRIPTION
@mbuit82  and I just had a debugging session where we were confused about why the parameter table was completely empty.  Turns out there was a bug with the foreign keys in the forms table, so the entire parameter table got silently deleted.

Since we were both surprised by this behaviour I thought it might be helpful to add a warning message to tell the user that this is happening (and more importantly, why).

(Side note: Personally I think the *makecldf* command shouldn't remove stuff in the background *at all* but I'm guessing there's probably data sets out there that rely on this behaviour and I wouldn't want to break their stuff.)

While I was at it, I updated the CI to test against currently supported Python versions.
