### PR TITLE
Fix profile check for default/single profile datasets

### DIFF
--- a/src/pylexibank/commands/check_profile.py
+++ b/src/pylexibank/commands/check_profile.py
@@ -52,7 +52,7 @@ def check_profile(dataset, args):
         if not args.language or args.language == row["Language_ID"]:
             kw = dict(column="IPA")
             if 'Profile' in row:  # A multi-profile dataset.
-                kw['profile'] = row['Profile']
+                kw['profile'] = None if row['Profile'] == 'default' else row['Profile']
             tokens = [normalized(t) for t in (
                 dataset.tokenizer(row, row["Form"], **kw)
                 if dataset.tokenizer and not args.noprofile


### PR DESCRIPTION
Otherwise, the profile check fails for single profile datasets with the profile in default (`etc/orthography.tsv`) location.