### PR TITLE
add updates for consonant cluster check

### DIFF
--- a/src/pylexibank/commands/consonant_clusters.py
+++ b/src/pylexibank/commands/consonant_clusters.py
@@ -32,7 +32,7 @@ def compute_consonant_cluster(word, sound_names):
     for i, sound in enumerate(sound_names):
         if sound.split(" ")[-1] in ["diphthong", "vowel", "tone", "�", "marker"]:
             out += [[]]
-        elif sound.split(" ")[0] == 'syllabic':
+        elif 'syllabic' in sound.split(" "):
             out += [[]]
         else:
             out[-1] += [word[i]]

--- a/src/pylexibank/commands/consonant_clusters.py
+++ b/src/pylexibank/commands/consonant_clusters.py
@@ -28,9 +28,11 @@ def run(args):
 
 
 def compute_consonant_cluster(word, sound_names):
-    out = [[]] if sound_names[0].split(" ")[-1] in ["consonant", "cluster"] else []
+    out = [[]] if sound_names[0].split(" ")[-1] in ["consonant", "cluster", "∼"] else []
     for i, sound in enumerate(sound_names):
         if sound.split(" ")[-1] in ["diphthong", "vowel", "tone", "�", "marker"]:
+            out += [[]]
+        elif sound.split(" ")[0] == 'syllabic':
             out += [[]]
         else:
             out[-1] += [word[i]]


### PR DESCRIPTION
This PR does two things:

- Resolving #279  by identiyfing tildes as consonant, as done isn some lexibank datasets
- Excluding syllabic consonants; we had many large clusters which were irrelevant because syllabic consonants were part of them. The new code excludes those cases by retrieving this information and breaking up the clusters if identified as syllabic.